### PR TITLE
Add Thanos Snap Simulator

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import importlib.util
 
 # Set up the sidebar for navigation
 st.sidebar.title("Navigation")
-pages = ["Home", "About"]
+pages = ["Home", "About", "Thanos Snap"]
 selection = st.sidebar.radio("Go to", pages)
 
 # Load the pages from the `pages/` directory
@@ -21,3 +21,6 @@ if selection == "Home":
 elif selection == "About":
     about = load_page("about")
     about.main()
+elif selection == "Thanos Snap":
+    thanos_snap = load_page("thanos_snap")
+    thanos_snap.main()

--- a/pages/thanos_snap.py
+++ b/pages/thanos_snap.py
@@ -1,0 +1,38 @@
+import streamlit as st
+import random
+
+def main():
+    st.title("Thanos Snap Simulator")
+    st.write("Click the Snap! button to see if you survived or got dusted…")
+
+    thanos_ascii_art = '''
+⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⣀⣀⣀⣀⣀⠀⠀⠀⠀⠀⠀⠀
+⠀⠀⠀⢀⣠⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣤⡀⠀⠀⠀
+⠀⠀⣠⣿⣿⣿⡿⠻⣿⣿⣿⣿⣿⣿⠟⢿⣿⣿⣿⣆⠀⠀
+⠀⢠⣿⣿⣯⣉⣿⣄⣹⣿⣿⣿⣿⣏⣠⣟⡉⣽⣿⣿⡄⠀
+⠀⢸⣿⣿⠟⠛⠉⠉⠛⠻⣿⣿⠟⠛⠉⠙⠛⢿⣿⣿⡇⠀
+⣠⣾⣿⣿⣶⣾⡀⠀⣴⣦⣾⣷⣴⣆⠀⣀⣷⣾⣿⣿⣷⡄
+⣿⣿⣿⣿⠟⢿⡿⠻⣿⣿⣿⣿⣿⣿⠿⢿⡿⠻⣿⣿⣿⡇
+⢻⣿⣿⣿⣧⠈⢿⡀⠹⣄⣈⣁⣰⠏⢠⡿⠀⣼⣿⣿⣿⡇
+⠀⣿⣿⣿⣿⣧⠀⣿⣀⣹⣿⣿⣇⣠⣿⠀⣼⣿⣿⣿⣿⠀
+⠀⣿⣿⣿⣿⣿⡿⠿⠛⠛⠛⠛⠛⠛⠻⢿⣿⣿⣿⣿⣿⠀
+⠀⢿⣿⣿⣿⣿⣀⣀⣤⣴⣶⣶⣦⣤⣀⣀⣿⣿⣿⣿⡟⠀
+⠀⠘⣿⣿⣿⡟⢻⣿⠉⣿⡇⢸⣿⠉⣿⡟⢻⣿⣿⣿⠁⠀
+⠀⠀⠸⣿⣿⡇⢸⣿⠀⣿⡇⢸⣿⠀⣿⡇⢸⣿⣿⠇⠀⠀
+⠀⠀⠀⠹⣿⡇⢸⣿⠀⣿⡇⢸⣿⠀⣿⡇⢸⣿⠏⠀⠀⠀
+⠀⠀⠀⠀⠀⠁⠈⠉⠀⠉⠁⠈⠉⠀⠉⠁⠈⠀⠀⠀⠀⠀'''
+
+    st.write(thanos_ascii_art)
+
+    entropy = st.slider("Adjust Entropy", 0, 100, 50)
+
+    if st.button("Snap!"):
+        if random.randint(0, 100) < entropy:
+            result = "You got dusted…"
+        else:
+            result = "You survived!"
+        st.write(result)
+        st.image("https://art.pixilart.com/d9aeb66792ae67c.gif")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #5

Add Thanos Snap Simulator feature.

* **New Page**: Add a new page "Thanos Snap" to the navigation sidebar in `app.py`.
* **Thanos Snap Functionality**: Create `pages/thanos_snap.py` to include:
  - A "Snap!" button that randomly shows "You survived!" or "You got dusted…".
  - A slider to adjust entropy, determining the probability of survival.
  - Thanos ASCII art above the Snap! button.
  - Display a Thanos snap gif after executing the Snap! button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/im45145v/SYH_Streamlit/pull/10?shareId=0a276e55-405a-467d-93f5-8e11df57c97d).