### PR TITLE
Add about page content

### DIFF
--- a/pages/about.py
+++ b/pages/about.py
@@ -1,5 +1,170 @@
 import streamlit as st
 
 def main():
-    st.title("About the Marvel Streamlit App")
-    st.write("This app is a multi-page Streamlit application with a sidebar for navigation. Use the sidebar to navigate to different pages and explore the features of the app.")
+    st.title("About ScrapYard Hyderabad")
+    st.markdown("""
+   # Hack Club Flag - Scrapyard
+
+**Build stupid stuff, get stupid prizes.**  
+**Hyderabad - March 15-16**
+
+**Venue:**  
+- Blue paper star  
+- Yellow paper star  
+- Pink paper star  
+
+**[SIGN UP](#)**
+
+---
+
+## What's Scrapyard Hyderabad?
+
+Scrapyard Hyderabad is a hackathon for high schoolers happening in Hyderabad, where you can make the stupidest things you can think of! Anything—from a lamp that flashes faster the slower you type, to ideas you wouldn’t dare consider useful—goes at Scrapyard. No matter your experience, Scrapyard Hyderabad needs you and your scrappy ideas!
+
+---
+
+## VENUE
+
+*Leaflet | © OpenStreetMap contributors*
+
+---
+
+## PARTNERS AND SPONSORS
+
+### Gold Sponsors
+- Place Holder Sponsorship Image  
+  **This Could Be You!**
+
+### Silver Sponsors
+- Github  
+- Github
+
+### Bronze Sponsors
+- The Linux Foundation  
+- The Linux Foundation
+
+### In-Kind Sponsors
+- .xyz Domains  
+- .xyz Domains  
+- Blue Cloud Softech  
+- Blue Cloud Softech
+
+### Partners
+- Sreenidhi Photography Club  
+- Sreenidhi Photography Club
+
+---
+
+## Our Team
+
+- **Sannihith Madasu**  
+  *Lead Organizer*  
+  [sannihithmadasu@gmail.com](mailto:sannihithmadasu@gmail.com) • [@sannihithmadasu](#)
+
+- **Atharv Kopparthi**  
+  *Co-Organizer*  
+  [atharv.kopp@gmail.com](mailto:atharv.kopp@gmail.com)
+
+- **Katta Hima Vamsi**  
+  *Co-Organizer*  
+  [hvkatta@gmail.com](mailto:hvkatta@gmail.com) • [@hima-vamsi-katta](#)
+
+- **Daksh Kaza**  
+  *Organizing Committee Head*  
+  [dakshcane@gmail.com](mailto:dakshcane@gmail.com)
+
+- **Amay Bhattacharya**  
+  *Design Lead*  
+  [amay.bhattacharya@gmail.com](mailto:amay.bhattacharya@gmail.com) • [@amay-bhattacharya](#)
+
+- **Arvesh Borkar**  
+  *Marketing Lead*  
+  [arvesh.borkar@gmail.com](mailto:arvesh.borkar@gmail.com) • [@arveshborkar](#)
+
+- **D.S.S. Prajwal Sarma**  
+  *Sponsorship Liaison*  
+  [saiprajwal2509@gmail.com](mailto:saiprajwal2509@gmail.com) • [@prajwaldoranala](#)
+
+- **Lohit Reddy Maddu**  
+  *Finance Lead*  
+  [lohitmaddu@gmail.com](mailto:lohitmaddu@gmail.com) • [@lohit-reddy-maddu](#)
+
+### Volunteers
+- **Akshay Lokerao** • [@akshay-lokerao](#)
+- **Avyay Lokerao** • [@avyay-lokerao](#)
+- **E.V Aryan** • [@aryan-e-v](#)
+
+---
+
+## What's Happening at Scrapyard Hyderabad?
+
+Scrapyard Hyderabad is a 24-hour event. Here's the rough schedule:
+
+- **11:00 AM:** Doors open  
+- **12:00 PM:** Opening ceremony  
+- **12:00 PM:** Team formation  
+- **12:30 PM:** Lunch  
+- **1:30 PM:** Work Session 1  
+- **2:15 PM:** Workshop 1  
+- **3:15 PM:** Work Session 2  
+- **4:15 PM:** Workshop 2  
+- **7:30 PM:** Dinner  
+- **8:30 PM:** Workshop 3  
+- **9:15 PM:** Work Session 3  
+- **10:15 PM:** Midnight surprise  
+- **12:00 AM:** Work Session 4  
+- **1:00 AM:** Submission  
+- **8:30 AM:** Judging  
+- **9:30 AM:** Awards Ceremony & Closing Ceremony  
+- **10:30 AM:** End
+
+---
+
+## Can't Make It to Hyderabad?
+
+There are **100+ other Scrapyard events happening around the world!**
+
+*Leaflet | © OpenStreetMap contributors*
+
+---
+
+## Frequently Asked Questions
+
+**Who can participate in Scrapyard?**  
+All high-school & upper-middle-school aged students are welcome to come! You don't have to be a member of the Hack Club community or be a Hack Club leader.
+
+**All this, for free?**  
+Yep! Food, swag, and good vibes are all included.
+
+**What do I need?**  
+Your laptop, chargers, and an open mind! If you're attending an overnight event, bring toiletries and sleeping bags too. Additionally, if you plan to work on a hardware project, bring the necessary tools.
+
+**I’m not good at coding. Can I still participate?**  
+This hackathon is for creatives of all skill levels! We’ll have workshops and other events—join us and let's learn together. For some introductory projects, check out [Hack Club Workshops](#).
+
+**What can I make at Scrapyard?**  
+The scrappiest thing you can imagine—jank is encouraged. Games? Apps? Websites? Programming languages? Hardware? You name it! We’ll have plenty of resources and mentors to help you out.
+
+**What has Hack Club done before?**  
+Hack Club has run an overnight hackathon in San Francisco, a Game Jam across 50 cities, a hackathon on a train from Vermont to Los Angeles, and much more!
+
+**What if my parents are concerned?**  
+We're here to help! Our parent's guide will be released soon, but in the meantime, they can reach out at [sannihith.hyderabad@scrapyard.hackclub.com](mailto:sannihith.hyderabad@scrapyard.hackclub.com).
+
+**What if I have more questions?**  
+Feel free to contact us in the **#scrapyard-hyderabad** channel on the Hack Club Slack or email [sannihith.hyderabad@scrapyard.hackclub.com](mailto:sannihith.hyderabad@scrapyard.hackclub.com).
+
+---
+
+## Sign Up
+
+**[SIGN UP FOR SCRAPYARD Hyderabad](#)**
+
+---
+
+*Scrapyard – Made with ♡ by teenagers, for teenagers at Hack Club*  
+*Hack Club ・ Slack ・ Clubs ・ Hackathons*
+
+    """)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #13

Update the about page to include information about ScrapYard Hyderabad.

* Change the title to "About ScrapYard Hyderabad".
* Add a detailed description of ScrapYard Hyderabad, its mission, and its services.
* Add Markdown formatting to the description.
* Include sections for venue, partners and sponsors, team members, event schedule, and frequently asked questions.
* Add a sign-up link for the event.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/im45145v/SYH_Streamlit/pull/14?shareId=73e0951b-cea8-4b07-8c12-e2bbc1f7eb4c).